### PR TITLE
Add support for alternative Docker repository and implement tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ docker run -it -d -p 25565:25565 -e MINECRAFT_EULA=true endkind/papermc:1.20.1
 
 By specifying a version like 1.20.1, you ensure that your server runs a known and tested version of PaperMC.
 
+### Alternative Repository Name
+
+The image is also available under `endkind/paper`.
+
+This repository name was created accidentally during a configuration change. Since it received active usage before the issue was noticed, it remains available and continues to receive the same image updates for compatibility.
+
+The primary and recommended repository is `endkind/papermc`.
+
 ### Versions Overview
 
 The current support status for all versions is also available on the live status page:

--- a/build.py
+++ b/build.py
@@ -47,7 +47,15 @@ def build(tag: str) -> Result[str, str]:
         print(f"Build context: {context_path}")
         print(f"Command: {' '.join(cmd)}")
 
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+        if len(DockerConfig.ALT_IMAGE_NAME) > 0:
+            for alt_name in DockerConfig.ALT_IMAGE_NAME:
+                alt_image_name = f"endkind/{alt_name}:{tag}"
+                tag_cmd = ["docker", "tag", image_name, alt_image_name]
+                print(f"Tagging Docker image: {alt_image_name}")
+                print(f"Command: {' '.join(tag_cmd)}")
+                subprocess.run(tag_cmd, capture_output=True, text=True, check=True)
 
         return Ok(f"Docker image '{image_name}' built successfully")
 

--- a/config/docker.py
+++ b/config/docker.py
@@ -1,5 +1,6 @@
-from typing import Final
+from typing import Final, List
 
 
 class DockerConfig:
     IMAGE_NAME: Final[str] = "papermc"
+    ALT_IMAGE_NAME: Final[List[str]] = ["paper"]

--- a/push.py
+++ b/push.py
@@ -35,7 +35,15 @@ def push(tag: str) -> Result[str, str]:
         print(f"Pushing Docker image: {image_name}")
         print(f"Command: {' '.join(cmd)}")
 
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+        if len(DockerConfig.ALT_IMAGE_NAME) > 0:
+            for alt_name in DockerConfig.ALT_IMAGE_NAME:
+                alt_image_name = f"endkind/{alt_name}:{tag}"
+                push_cmd = ["docker", "push", alt_image_name]
+                print(f"Pushing Docker image: {alt_image_name}")
+                print(f"Command: {' '.join(push_cmd)}")
+                subprocess.run(push_cmd, capture_output=True, text=True, check=True)
 
         return Ok(f"Docker image '{image_name}' pushed successfully")
 


### PR DESCRIPTION
This pull request adds support for building and pushing Docker images under an alternative repository name (`endkind/paper`) in addition to the primary (`endkind/papermc`). It also updates the documentation to explain the existence and use of the alternative repository. The main changes are grouped below:

**Docker image build and push enhancements:**

* Updated `build.py` so that when building the image, it also tags the image as `endkind/paper` in addition to `endkind/papermc` if alternative image names are configured.
* Updated `push.py` to push the Docker image under all configured alternative names, ensuring both `endkind/papermc` and `endkind/paper` are pushed to the registry.
* Modified `config/docker.py` to define `ALT_IMAGE_NAME` as a list (defaulting to `["paper"]`) for managing alternative image tags.

**Documentation updates:**

* Updated `README.md` to document the existence of the alternative repository (`endkind/paper`), clarify its origin, and recommend using the primary repository (`endkind/papermc`).